### PR TITLE
fix newest Sanic requires app name

### DIFF
--- a/comrade/index.py
+++ b/comrade/index.py
@@ -21,7 +21,7 @@ from .blueprints.template import template_bp
 from .blueprints.views import views_bp
 from .connections import clusters, load_clients
 
-app = Sanic()
+app = Sanic(name="Comrade")
 current_dir = path.dirname(__file__)
 app.static('/static', f'{current_dir}/static')
 app.blueprint(views_bp, url_prefix='/api/v1/views')


### PR DESCRIPTION
Newest version of package Sanic requires "name" option to be passed to constructor, otherwise Docker container crashes with such error:

> Traceback (most recent call last):
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/bin/comrade", line 33, in <module>
    sys.exit(load_entry_point('elasticsearch-comrade', 'console_scripts', 'comrade')())
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/bin/comrade", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 96, in load
    module = import_module(match.group('module'))
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/comrade/index.py", line 24, in <module>
    app = Sanic()
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/sanic/app.py", line 58, in __init__
    "Sanic instance cannot be unnamed. "
sanic.exceptions.SanicException: Sanic instance cannot be unnamed. Please use Sanic(name='your_application_name') instead.

