### PR TITLE
fix error 'noop' object is not iterable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     packages=['comrade'] + packages,
     include_package_data=True,
     install_requires=[
+        'aiohttp<=3.6.2',
         'sanic',
         'ujson',
         'elasticsearch-async',


### PR DESCRIPTION
On newest Docker image build API-route "/api/v1/cluster/info/<cluster_name>" always fails because Python package "aiohttp" (probably method aiohttp.helpers.noop) contains some breaking changes.
Web Application looks like this:
![image](https://user-images.githubusercontent.com/37391150/103611734-ed69ea80-4f33-11eb-9d7d-c3378d97a267.png)

And error log contains such lines:

> [2021-01-05 04:59:58 +0000] [19] [ERROR] 'noop' object is not iterable
Traceback (most recent call last):
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/sanic/app.py", line 909, in handle_request
    response = await response
  File "/app/comrade/blueprints/cluster.py", line 42, in get_cluster_info
    await client.ping()
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/elasticsearch_async/transport.py", line 150, in main_loop
    method, url, params, body, headers=headers, ignore=ignore, timeout=timeout)
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/elasticsearch_async/connection.py", line 115, in perform_request

Instruction aiohttp/client_reqrep.py:968 which is a reason of exception:
![image](https://user-images.githubusercontent.com/37391150/103612084-b5af7280-4f34-11eb-8e91-c7f38a41caaa.png)

This PR fixes that error by forcing to install aiohttp v3.6.2
TODO. Find way to get it working on newest aiohttp v3.7.*